### PR TITLE
Enhance workaround for WeakMap with jruby >= 9.4.6.0

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -825,7 +825,7 @@ module ActiveRecord
 end
 
 # Workaround for https://github.com/jruby/jruby/issues/6267
-if RUBY_ENGINE == "jruby"
+if defined?(JRUBY_VERSION) && Gem::Version.new(JRUBY_VERSION) < Gem::Version.new("9.4.6.0")
   require "jruby"
 
   class org.jruby::RubyObjectSpace::WeakMap


### PR DESCRIPTION
Since jruby 9.4.6.0 the missing methods on ObjectSpace::WeakMap have been implemented.

See: https://github.com/jruby/jruby/pull/6683

Without this fix the gem does not work on jruby 9.4.6.0.
